### PR TITLE
 Re-introduce maven assembly plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,45 +1,101 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <artifactId>core-utils-lib</artifactId>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <configuration>
+              <archive>
+                <manifest>
+                  <mainClass>life.qbic.cli.PostregistrationToolEntryPoint</mainClass>
+                </manifest>
+              </archive>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+            </configuration>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+        <groupId>org.apache.maven.plugins</groupId>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <artifactId>commons-lang3</artifactId>
+      <groupId>org.apache.commons</groupId>
+    </dependency>
+    <dependency>
+      <artifactId>picocli</artifactId>
+      <groupId>info.picocli</groupId>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
+    <dependency>
+      <artifactId>micronaut-http-client</artifactId>
+      <groupId>io.micronaut</groupId>
+      <version>1.2.11</version>
+    </dependency>
+    <dependency>
+      <artifactId>org.everit.json.schema</artifactId>
+      <groupId>com.github.everit-org.json-schema</groupId>
+      <version>1.12.1</version>
+    </dependency>
+    <dependency>
+      <artifactId>spock-core</artifactId>
+      <groupId>org.spockframework</groupId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <artifactId>data-model-lib</artifactId>
+      <groupId>life.qbic</groupId>
+      <version>1.9.0</version>
+    </dependency>
+  </dependencies>
+  <description>Collection of non-Vaadin, non-Liferay utilities.</description>
   <modelVersion>4.0.0</modelVersion>
+  <name>Core Utilities Library</name>
+  <packaging>jar</packaging>
   <parent>
-    <groupId>life.qbic</groupId>
     <artifactId>parent-pom</artifactId>
+    <groupId>life.qbic</groupId>
     <version>2.2.0</version>
   </parent>
-  <artifactId>core-utils-lib</artifactId>
-  <version>1.5.0-SNAPSHOT</version>
-  <name>Core Utilities Library</name>
-  <url>http://github.com/qbicsoftware/core-utils-lib</url>
-  <description>Collection of non-Vaadin, non-Liferay utilities.</description>
-  <packaging>jar</packaging>
   <!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->
   <repositories>
     <repository>
+      <id>nexus-snapshots</id>
+      <name>QBiC Snapshots</name>
       <releases>
         <enabled>false</enabled>
       </releases>
       <snapshots>
+        <checksumPolicy>fail</checksumPolicy>
         <enabled>true</enabled>
         <updatePolicy>always</updatePolicy>
-        <checksumPolicy>fail</checksumPolicy>
       </snapshots>
-      <id>nexus-snapshots</id>
-      <name>QBiC Snapshots</name>
       <url>https://qbic-repo.am10.uni-tuebingen.de/repository/maven-snapshots</url>
     </repository>
     <repository>
+      <id>nexus-releases</id>
+      <name>QBiC Releases</name>
       <releases>
+        <checksumPolicy>fail</checksumPolicy>
         <enabled>true</enabled>
         <updatePolicy>always</updatePolicy>
-        <checksumPolicy>fail</checksumPolicy>
       </releases>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>nexus-releases</id>
-      <name>QBiC Releases</name>
       <url>https://qbic-repo.am10.uni-tuebingen.de/repository/maven-releases</url>
     </repository>
     <repository>
@@ -47,35 +103,6 @@
       <url>https://jitpack.io</url>
     </repository>
   </repositories>
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>info.picocli</groupId>
-      <artifactId>picocli</artifactId>
-    </dependency>
-    <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
-    <dependency>
-      <groupId>io.micronaut</groupId>
-      <artifactId>micronaut-http-client</artifactId>
-      <version>1.2.11</version>
-    </dependency>
-    <dependency>
-      <groupId>com.github.everit-org.json-schema</groupId>
-      <artifactId>org.everit.json.schema</artifactId>
-      <version>1.12.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.spockframework</groupId>
-      <artifactId>spock-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>life.qbic</groupId>
-      <artifactId>data-model-lib</artifactId>
-      <version>1.9.0</version>
-    </dependency>
-  </dependencies>
+  <url>http://github.com/qbicsoftware/core-utils-lib</url>
+  <version>1.5.0-SNAPSHOT</version>
 </project>


### PR DESCRIPTION
This plugin is needed in order to provide a full JAR archive
with batteries (dependencies) included. The full archive
can be used in environments like Liferay / openBIS in order to
provide the core-utils-lib functionality system-wide.
