### PR TITLE
Upgrade Parent POM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ logs/
 
 # Other
 **/.factorypath
+.flattened-pom.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ branches:
   only:
   - master
   - development
-  - /release.*/
+  - release/*
+  - hotfix/*
   # Travis treats pushed tags as branches
   - /^[vV]?\d+\.\d+\.\d+$/ # matches e.g., v1.2.3, 1.2.3, V1.2.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ branches:
   only:
   - master
   - development
-  - release\/.*
-  - hotfix\/.*
+  - /^release\/.*$/
+  - /^hotfix\/.*$/
   # Travis treats pushed tags as branches
   - /^[vV]?\d+\.\d+\.\d+$/ # matches e.g., v1.2.3, 1.2.3, V1.2.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ branches:
   only:
   - master
   - development
-  - release/*
-  - hotfix/*
+  - release\/.*
+  - hotfix\/.*
   # Travis treats pushed tags as branches
   - /^[vV]?\d+\.\d+\.\d+$/ # matches e.g., v1.2.3, 1.2.3, V1.2.3
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <artifactId>data-model-lib</artifactId>
       <groupId>life.qbic</groupId>
-      <version>1.9.4</version>
+      <version>1.11.0</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,32 +4,50 @@
   xmlns="http://maven.apache.org/POM/4.0.0"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <artifactId>core-utils-lib</artifactId>
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <executions>
-          <execution>
-            <configuration>
-              <archive>
-                <manifest>
-                  <mainClass>life.qbic.cli.PostregistrationToolEntryPoint</mainClass>
-                </manifest>
-              </archive>
-              <descriptorRefs>
-                <descriptorRef>jar-with-dependencies</descriptorRef>
-              </descriptorRefs>
-            </configuration>
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <phase>package</phase>
-          </execution>
-        </executions>
-        <groupId>org.apache.maven.plugins</groupId>
-      </plugin>
-    </plugins>
-  </build>
+  <description>Collection of non-Vaadin, non-Liferay utilities.</description>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Core Utilities Library</name>
+  <version>1.7.0</version>
+  <url>http://github.com/qbicsoftware/core-utils-lib</url>
+  <packaging>jar</packaging>
+  <parent>
+    <artifactId>parent-pom</artifactId>
+    <groupId>life.qbic</groupId>
+    <version>3.1.0</version>
+  </parent>
+  <!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->
+  <repositories>
+    <repository>
+      <id>nexus-snapshots</id>
+      <name>QBiC Snapshots</name>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <checksumPolicy>fail</checksumPolicy>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+      <url>http://qbic-repo.qbic.uni-tuebingen.de:8081/repository/maven-snapshots</url>
+    </repository>
+    <repository>
+      <id>nexus-releases</id>
+      <name>QBiC Releases</name>
+      <releases>
+        <checksumPolicy>fail</checksumPolicy>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <url>http://qbic-repo.qbic.uni-tuebingen.de:8081/repository/maven-releases</url>
+    </repository>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+  </repositories>
   <dependencies>
     <dependency>
       <artifactId>commons-lang3</artifactId>
@@ -60,49 +78,56 @@
       <groupId>life.qbic</groupId>
       <version>1.9.4</version>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.8.4</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.18.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.19.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-reflect</artifactId>
+      <version>1.6.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
-  <description>Collection of non-Vaadin, non-Liferay utilities.</description>
-  <modelVersion>4.0.0</modelVersion>
-  <name>Core Utilities Library</name>
-  <packaging>jar</packaging>
-  <parent>
-    <artifactId>parent-pom</artifactId>
-    <groupId>life.qbic</groupId>
-    <version>2.2.0</version>
-  </parent>
-  <!-- we only need to tell maven where to find our parent pom and other QBiC dependencies -->
-  <repositories>
-    <repository>
-      <id>nexus-snapshots</id>
-      <name>QBiC Snapshots</name>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <checksumPolicy>fail</checksumPolicy>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
-      <url>https://qbic-repo.am10.uni-tuebingen.de/repository/maven-snapshots</url>
-    </repository>
-    <repository>
-      <id>nexus-releases</id>
-      <name>QBiC Releases</name>
-      <releases>
-        <checksumPolicy>fail</checksumPolicy>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <url>https://qbic-repo.am10.uni-tuebingen.de/repository/maven-releases</url>
-    </repository>
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-  </repositories>
-  <url>http://github.com/qbicsoftware/core-utils-lib</url>
-  <version>1.6.0</version>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <configuration>
+              <archive>
+                <manifest>
+                  <mainClass>life.qbic.cli.PostregistrationToolEntryPoint</mainClass>
+                </manifest>
+              </archive>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+            </configuration>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+        <groupId>org.apache.maven.plugins</groupId>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
The new parent POM 3.1.0 is integrated, braking dependencies are updated accordingly.

Some minor refactoring of the POM has been done to improve the readability