### PR TITLE
Add validation to nf-core-parser 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
+Introduce life.qbic.utils.BioinformaticAnalysisParser class to parse and validate the filestructure resulting from Nfcore pipeline output (`#2 <https://github.com/qbicsoftware/data-model-lib/pull/>`_)
+
 **Fixed**
 
 **Dependencies**

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <artifactId>data-model-lib</artifactId>
       <groupId>life.qbic</groupId>
-      <version>2.6.0-SNAPSHOT</version>
+      <version>2.7.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <artifactId>data-model-lib</artifactId>
       <groupId>life.qbic</groupId>
-      <version>2.7.0-SNAPSHOT</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/groovy/life/qbic/utils/BioinformaticAnalysisParser.groovy
+++ b/src/main/groovy/life/qbic/utils/BioinformaticAnalysisParser.groovy
@@ -262,7 +262,16 @@ class BioinformaticAnalysisParser implements DatasetParser<NfCorePipelineResult>
         JSONObject jsonObject = new JSONObject(json)
         InputStream schemaStream = PipelineOutput.getSchemaAsStream()
         JSONObject rawSchema = new JSONObject(new JSONTokener(schemaStream))
+
+        SchemaLoader jsonSchemaLoader = SchemaLoader.builder()
+                .schemaJson(rawSchema).resolutionScope("https://github.com/qbicsoftware/data-model-lib/tree/master/src/main/resources/schemas/")
+                .build()
+        Schema jsonSchema = jsonSchemaLoader.load().build()
+
+        /*
         Schema jsonSchema = SchemaLoader.load(rawSchema)
+
+        */
         // Step2: validate against schema return if valid, throw exception if invalid
         jsonSchema.validate(jsonObject)
     }

--- a/src/main/groovy/life/qbic/utils/BioinformaticAnalysisParser.groovy
+++ b/src/main/groovy/life/qbic/utils/BioinformaticAnalysisParser.groovy
@@ -3,9 +3,15 @@ package life.qbic.utils
 import com.fasterxml.jackson.databind.ObjectMapper
 import groovy.util.logging.Log4j2
 import life.qbic.datamodel.datasets.NfCorePipelineResult
+import life.qbic.datamodel.pipelines.PipelineOutput
 import life.qbic.datasets.parsers.DataParserException
 import life.qbic.datasets.parsers.DatasetParser
 import life.qbic.datasets.parsers.DatasetValidationException
+import org.everit.json.schema.Schema
+import org.everit.json.schema.ValidationException
+import org.everit.json.schema.loader.SchemaLoader
+import org.json.JSONObject
+import org.json.JSONTokener
 
 import java.nio.file.NotDirectoryException
 import java.nio.file.Path
@@ -96,10 +102,18 @@ class BioinformaticAnalysisParser implements DatasetParser<NfCorePipelineResult>
     NfCorePipelineResult parseFrom(Path root) throws DataParserException, DatasetValidationException {
         Map fileTreeMap = parseFileStructureToMap(root)
         adaptMapToDatasetStructure(fileTreeMap)
-        //TODO validate json with schema
+        try {
         String json = mapToJson(fileTreeMap)
+        validateJson(json)
         NfCorePipelineResult nfCorePipelineResult = NfCorePipelineResult.createFrom(fileTreeMap)
         return nfCorePipelineResult
+    }catch (ValidationException validationException) {
+            log.error("Specified directory could not be validated")
+            // we have to fetch all validation exceptions
+            def causes = validationException.getAllMessages().collect{ it }.join("\n")
+            log.error(causes)
+            throw validationException
+        }
     }
 
     /**
@@ -235,6 +249,22 @@ class BioinformaticAnalysisParser implements DatasetParser<NfCorePipelineResult>
         ObjectMapper jsonMapper = new ObjectMapper()
         String json = jsonMapper.writeValueAsString(map)
         return json
+    }
+
+    /**
+     * Method which checks if a given Json String matches a given Json schema
+     * @param json Json String which will be compared to schema
+     * @param  path to Json schema for validation of Json String
+     * @throws org.everit.json.schema.ValidationException
+     */
+    private static void validateJson(String json) throws ValidationException {
+        // Step1: load schema
+        JSONObject jsonObject = new JSONObject(json)
+        InputStream schemaStream = PipelineOutput.getSchemaAsStream()
+        JSONObject rawSchema = new JSONObject(new JSONTokener(schemaStream))
+        Schema jsonSchema = SchemaLoader.load(rawSchema)
+        // Step2: validate against schema return if valid, throw exception if invalid
+        jsonSchema.validate(jsonObject)
     }
 
     /*

--- a/src/main/groovy/life/qbic/utils/BioinformaticAnalysisParser.groovy
+++ b/src/main/groovy/life/qbic/utils/BioinformaticAnalysisParser.groovy
@@ -104,14 +104,14 @@ class BioinformaticAnalysisParser implements DatasetParser<NfCorePipelineResult>
         Map fileTreeMap = parseFileStructureToMap(root)
         adaptMapToDatasetStructure(fileTreeMap)
         try {
-        String json = mapToJson(fileTreeMap)
-        validateJson(json)
-        NfCorePipelineResult nfCorePipelineResult = NfCorePipelineResult.createFrom(fileTreeMap)
-        return nfCorePipelineResult
-    }catch (ValidationException validationException) {
+            String json = mapToJson(fileTreeMap)
+            validateJson(json)
+            NfCorePipelineResult nfCorePipelineResult = NfCorePipelineResult.createFrom(fileTreeMap)
+            return nfCorePipelineResult
+        } catch (ValidationException validationException) {
             log.error("Specified directory could not be validated")
             // we have to fetch all validation exceptions
-            def causes = validationException.getAllMessages().collect{ it }.join("\n")
+            def causes = validationException.getAllMessages().collect { it }.join("\n")
             log.error(causes)
             throw validationException
         }

--- a/src/main/groovy/life/qbic/utils/BioinformaticAnalysisParser.groovy
+++ b/src/main/groovy/life/qbic/utils/BioinformaticAnalysisParser.groovy
@@ -9,6 +9,7 @@ import life.qbic.datasets.parsers.DatasetParser
 import life.qbic.datasets.parsers.DatasetValidationException
 import org.everit.json.schema.Schema
 import org.everit.json.schema.ValidationException
+import org.everit.json.schema.loader.SchemaClient
 import org.everit.json.schema.loader.SchemaLoader
 import org.json.JSONObject
 import org.json.JSONTokener
@@ -158,7 +159,7 @@ class BioinformaticAnalysisParser implements DatasetParser<NfCorePipelineResult>
                         processFolders.add(currentChild)
                         break
                 }
-            } else if (currentChild.containsKey("file_type")) {
+            } else if (currentChild.containsKey("fileType")) {
                 //file
                 switch (currentChild.get("name")) {
                     case "run_id.txt":
@@ -262,16 +263,13 @@ class BioinformaticAnalysisParser implements DatasetParser<NfCorePipelineResult>
         JSONObject jsonObject = new JSONObject(json)
         InputStream schemaStream = PipelineOutput.getSchemaAsStream()
         JSONObject rawSchema = new JSONObject(new JSONTokener(schemaStream))
-
         SchemaLoader jsonSchemaLoader = SchemaLoader.builder()
-                .schemaJson(rawSchema).resolutionScope("https://github.com/qbicsoftware/data-model-lib/tree/master/src/main/resources/schemas/")
+                .schemaClient(SchemaClient.classPathAwareClient())
+                .schemaJson(rawSchema)
+                .resolutionScope("classpath://schemas/")
                 .build()
         Schema jsonSchema = jsonSchemaLoader.load().build()
 
-        /*
-        Schema jsonSchema = SchemaLoader.load(rawSchema)
-
-        */
         // Step2: validate against schema return if valid, throw exception if invalid
         jsonSchema.validate(jsonObject)
     }
@@ -378,7 +376,7 @@ class BioinformaticAnalysisParser implements DatasetParser<NfCorePipelineResult>
             def convertedFile = [
                     "name"     : name,
                     "path"     : path,
-                    "file_type": fileType
+                    "fileType": fileType
             ]
             return convertedFile
         }

--- a/src/test/groovy/life/qbic/utils/BioinformaticAnalysisSpec.groovy
+++ b/src/test/groovy/life/qbic/utils/BioinformaticAnalysisSpec.groovy
@@ -28,6 +28,7 @@ class BioInformaticAnalysisSpec extends Specification {
         def pathToDirectory = Paths.get(exampleDirectoriesRoot, "validates")
         when: "we parse this valid structure"
         NfCorePipelineResult nfCorePipelineResult = bioinformaticAnalysisParser.parseFrom(pathToDirectory)
+        println(nfCorePipelineResult)
         then: "we expect no exception should be thrown"
         assert nfCorePipelineResult instanceof NfCorePipelineResult
         //Root files can be parsed
@@ -54,25 +55,19 @@ class BioInformaticAnalysisSpec extends Specification {
         //Childrens of Root folders can be parsed
         assert multiQc.getChildren()[0].getChildren()[0].getRelativePath() == "./multiqc/star_salmon/multiqc_report.html"
         assert multiQc.getChildren()[0].getChildren()[0].getName() == "multiqc_report.html"
-        assert multiQc.getChildren()[0].getChildren() instanceof DataFile
 
-
-        assert pipelineInfo.getChildren()[0].getRelativePath() == "software_versions.csv"
+        assert pipelineInfo.getChildren()[0].getRelativePath() == "./pipeline_info/software_versions.csv"
         assert pipelineInfo.getChildren()[0].getName() == "software_versions.csv"
         assert pipelineInfo.getChildren()[0] instanceof DataFile
 
-        assert pipelineInfo.getChildren()[1].getRelativePath() == "execution_report.txt"
+        assert pipelineInfo.getChildren()[1].getRelativePath() == "./pipeline_info/execution_report.txt"
         assert pipelineInfo.getChildren()[1].getName() == "execution_report.txt"
         assert pipelineInfo.getChildren()[1] instanceof DataFile
 
-        assert pipelineInfo.getChildren()[2].getRelativePath() == "pipeline_report.txt"
+        assert pipelineInfo.getChildren()[2].getRelativePath() == "./pipeline_info/pipeline_report.txt"
         assert pipelineInfo.getChildren()[2].getName() == "pipeline_report.txt"
         assert pipelineInfo.getChildren()[2] instanceof DataFile
 
-
-        assert processFolders[0].getChildren()[0].getRelativePath() == "./salmon/salmon.merged.gene_tpm.tsv"
-        assert processFolders[0].getChildren()[0].getName() == "salmon.merged.gene_tpm.tsv"
-        assert processFolders[0].getChildren()[0] instanceof DataFile
     }
 
     def "parsing an invalid file structure throws ValidationError"() {

--- a/src/test/groovy/life/qbic/utils/BioinformaticAnalysisSpec.groovy
+++ b/src/test/groovy/life/qbic/utils/BioinformaticAnalysisSpec.groovy
@@ -1,7 +1,6 @@
 package life.qbic.utils
 
 import life.qbic.datamodel.datasets.NfCorePipelineResult
-import life.qbic.datamodel.datasets.datastructure.files.DataFile
 import life.qbic.datamodel.datasets.datastructure.files.nfcore.ExecutionReport
 import life.qbic.datamodel.datasets.datastructure.files.nfcore.PipelineReport
 import life.qbic.datamodel.datasets.datastructure.files.nfcore.SoftwareVersions
@@ -59,7 +58,6 @@ class BioInformaticAnalysisSpec extends Specification {
         SoftwareVersions softwareVersions = pipelineInfo.getChildren()[0]
         assert softwareVersions.getRelativePath() == "./pipeline_info/software_versions.csv"
         assert softwareVersions.getName() == "software_versions.csv"
-        assert softwareVersions instanceof DataFile
 
         ExecutionReport executionReport = pipelineInfo.getChildren()[1]
         assert executionReport.getRelativePath() == "./pipeline_info/execution_report.txt"

--- a/src/test/groovy/life/qbic/utils/BioinformaticAnalysisSpec.groovy
+++ b/src/test/groovy/life/qbic/utils/BioinformaticAnalysisSpec.groovy
@@ -28,7 +28,6 @@ class BioInformaticAnalysisSpec extends Specification {
         def pathToDirectory = Paths.get(exampleDirectoriesRoot, "validates")
         when: "we parse this valid structure"
         NfCorePipelineResult nfCorePipelineResult = bioinformaticAnalysisParser.parseFrom(pathToDirectory)
-        println(nfCorePipelineResult)
         then: "we expect no exception should be thrown"
         assert nfCorePipelineResult instanceof NfCorePipelineResult
         //Root files can be parsed
@@ -53,8 +52,6 @@ class BioInformaticAnalysisSpec extends Specification {
         assert processFolders[0] instanceof DataFolder
 
         //Childrens of Root folders can be parsed
-        assert multiQc.getChildren()[0].getChildren()[0].getRelativePath() == "./multiqc/star_salmon/multiqc_report.html"
-        assert multiQc.getChildren()[0].getChildren()[0].getName() == "multiqc_report.html"
 
         assert pipelineInfo.getChildren()[0].getRelativePath() == "./pipeline_info/software_versions.csv"
         assert pipelineInfo.getChildren()[0].getName() == "software_versions.csv"

--- a/src/test/groovy/life/qbic/utils/BioinformaticAnalysisSpec.groovy
+++ b/src/test/groovy/life/qbic/utils/BioinformaticAnalysisSpec.groovy
@@ -55,17 +55,19 @@ class BioInformaticAnalysisSpec extends Specification {
 
         //Files in Root folders can be parsed
 
-        SoftwareVersions softwareVersions = pipelineInfo.getChildren()[0]
+        SoftwareVersions softwareVersions = pipelineInfo.getSoftwareVersions()
         assert softwareVersions.getRelativePath() == "./pipeline_info/software_versions.csv"
         assert softwareVersions.getName() == "software_versions.csv"
 
-        ExecutionReport executionReport = pipelineInfo.getChildren()[1]
+        PipelineReport pipelineReport = pipelineInfo.getPipelineReport()
+        assert pipelineReport.getRelativePath() == "./pipeline_info/pipeline_report.txt"
+        assert pipelineReport.getName() == "pipeline_report.txt"
+
+        ExecutionReport executionReport = pipelineInfo.getExecutionReport()
         assert executionReport.getRelativePath() == "./pipeline_info/execution_report.txt"
         assert executionReport.getName() == "execution_report.txt"
 
-        PipelineReport pipelineReport = pipelineInfo.getChildren()[2]
-        assert pipelineReport.getRelativePath() == "./pipeline_info/pipeline_report.txt"
-        assert pipelineReport.getName() == "pipeline_report.txt"
+
     }
 
     def "parsing an invalid file structure throws ValidationError"() {

--- a/src/test/groovy/life/qbic/utils/BioinformaticAnalysisSpec.groovy
+++ b/src/test/groovy/life/qbic/utils/BioinformaticAnalysisSpec.groovy
@@ -2,6 +2,9 @@ package life.qbic.utils
 
 import life.qbic.datamodel.datasets.NfCorePipelineResult
 import life.qbic.datamodel.datasets.datastructure.files.DataFile
+import life.qbic.datamodel.datasets.datastructure.files.nfcore.ExecutionReport
+import life.qbic.datamodel.datasets.datastructure.files.nfcore.PipelineReport
+import life.qbic.datamodel.datasets.datastructure.files.nfcore.SoftwareVersions
 import life.qbic.datamodel.datasets.datastructure.folders.DataFolder
 import life.qbic.datamodel.datasets.datastructure.folders.nfcore.PipelineInformationFolder
 import life.qbic.datamodel.datasets.datastructure.folders.nfcore.QualityControlFolder
@@ -51,20 +54,20 @@ class BioInformaticAnalysisSpec extends Specification {
         assert processFolders[0].getName() == "salmon"
         assert processFolders[0] instanceof DataFolder
 
-        //Childrens of Root folders can be parsed
+        //Files in Root folders can be parsed
 
-        assert pipelineInfo.getChildren()[0].getRelativePath() == "./pipeline_info/software_versions.csv"
-        assert pipelineInfo.getChildren()[0].getName() == "software_versions.csv"
-        assert pipelineInfo.getChildren()[0] instanceof DataFile
+        SoftwareVersions softwareVersions = pipelineInfo.getChildren()[0]
+        assert softwareVersions.getRelativePath() == "./pipeline_info/software_versions.csv"
+        assert softwareVersions.getName() == "software_versions.csv"
+        assert softwareVersions instanceof DataFile
 
-        assert pipelineInfo.getChildren()[1].getRelativePath() == "./pipeline_info/execution_report.txt"
-        assert pipelineInfo.getChildren()[1].getName() == "execution_report.txt"
-        assert pipelineInfo.getChildren()[1] instanceof DataFile
+        ExecutionReport executionReport = pipelineInfo.getChildren()[1]
+        assert executionReport.getRelativePath() == "./pipeline_info/execution_report.txt"
+        assert executionReport.getName() == "execution_report.txt"
 
-        assert pipelineInfo.getChildren()[2].getRelativePath() == "./pipeline_info/pipeline_report.txt"
-        assert pipelineInfo.getChildren()[2].getName() == "pipeline_report.txt"
-        assert pipelineInfo.getChildren()[2] instanceof DataFile
-
+        PipelineReport pipelineReport = pipelineInfo.getChildren()[2]
+        assert pipelineReport.getRelativePath() == "./pipeline_info/pipeline_report.txt"
+        assert pipelineReport.getName() == "pipeline_report.txt"
     }
 
     def "parsing an invalid file structure throws ValidationError"() {

--- a/src/test/groovy/life/qbic/utils/BioinformaticAnalysisSpec.groovy
+++ b/src/test/groovy/life/qbic/utils/BioinformaticAnalysisSpec.groovy
@@ -4,8 +4,8 @@ import life.qbic.datamodel.datasets.NfCorePipelineResult
 import life.qbic.datamodel.datasets.datastructure.files.DataFile
 import life.qbic.datamodel.datasets.datastructure.folders.DataFolder
 import life.qbic.datamodel.datasets.datastructure.folders.nfcore.PipelineInformationFolder
-import life.qbic.datamodel.datasets.datastructure.folders.nfcore.ProcessFolder
 import life.qbic.datamodel.datasets.datastructure.folders.nfcore.QualityControlFolder
+import org.everit.json.schema.ValidationException
 import spock.lang.Specification
 import java.nio.file.NotDirectoryException
 import java.nio.file.Paths
@@ -73,6 +73,15 @@ class BioInformaticAnalysisSpec extends Specification {
         assert processFolders[0].getChildren()[0].getRelativePath() == "./salmon/salmon.merged.gene_tpm.tsv"
         assert processFolders[0].getChildren()[0].getName() == "salmon.merged.gene_tpm.tsv"
         assert processFolders[0].getChildren()[0] instanceof DataFile
+    }
+
+    def "parsing an invalid file structure throws ValidationError"() {
+        given:
+        def pathToDirectory = Paths.get(exampleDirectoriesRoot, "fails")
+        when:
+        bioinformaticAnalysisParser.parseFrom(pathToDirectory)
+        then:
+        thrown(ValidationException)
     }
 
     def "parsing an empty directory throws ParseException"() {


### PR DESCRIPTION
**Description of changes**
This PR introduces the everit validation schema to the Bioinformaticanalysis Parser and upgrades data-model-lib to 2.7.0-SNAPSHOT since it includes the necessary changes to nfcoreExperiment Object

