### PR TITLE
Include groovydoc plugin in report generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,4 +209,12 @@
       </plugin>
     </plugins>
   </build>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>life.qbic</groupId>
+        <artifactId>groovydoc-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </reporting>
 </project>


### PR DESCRIPTION
**Description of changes**
This plugin enables the groovydoc maven plugin to function properly by including it in the report section of the pom.xml. 
This is necessary to include the linkage to the generated groovydocs in project overview page. 

**Additional context**
This can be easily tested by running `mvn site` and checking if there is a project reports section in the generated `index.html` file in the target/site/ directory. (Open it in your favorite browser to see the generated html document) 
Without the plugin addition to the ` pom.xml` the `index.html` will lack a dedicated project report section
![Bildschirmfoto 2021-07-07 um 16 48 56](https://user-images.githubusercontent.com/29627977/124781021-5d891580-df43-11eb-9361-2806c02a3fe0.png)
With the plugin addition to the ` pom.xml` the `index.html` will include the project reports section:
![Bildschirmfoto 2021-07-07 um 16 48 51](https://user-images.githubusercontent.com/29627977/124781084-6974d780-df43-11eb-977a-9b19c6424427.png)



