### PR TITLE
Hotfix 1.10.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,21 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.10.3 (2021-12-20)
+-------------------
+
+**Added**
+
+**Fixed**
+
+* CVE-2021-45105
+
+**Dependencies**
+
+* org.apache.logging.log4j:log4j-api:2.16.0 -> 2.17.0
+* org.apache.logging.log4j:log4j-core:2.16.0 -> 2.17.0
+
+**Deprecated**
 
 1.10.2 (2021-12-16)
 -------------------

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
       <maven.compiler.source>1.8</maven.compiler.source>
       <maven.compiler.target>1.8</maven.compiler.target>
-      <log4j.version>2.16.0</log4j.version>
+      <log4j.version>2.17.0</log4j.version>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <description>Collection of non-Vaadin, non-Liferay utilities.</description>
   <modelVersion>4.0.0</modelVersion>
   <name>Core Utilities Library</name>
-  <version>1.10.2</version> <!-- <<QUBE_FORCE_BUMP>> -->
+  <version>1.10.3</version> <!-- <<QUBE_FORCE_BUMP>> -->
   <url>https://github.com/qbicsoftware/core-utils-lib</url>
   <packaging>jar</packaging>
   <properties>


### PR DESCRIPTION
1.10.3 (2021-12-20)
-------------------

**Fixed**

* CVE-2021-45105

**Dependencies**

* org.apache.logging.log4j:log4j-api:2.16.0 -> 2.17.0
* org.apache.logging.log4j:log4j-core:2.16.0 -> 2.17.0
