### PR TITLE
Adapt parsing of execution report to new regex

### DIFF
--- a/src/main/groovy/life/qbic/utils/BioinformaticAnalysisParser.groovy
+++ b/src/main/groovy/life/qbic/utils/BioinformaticAnalysisParser.groovy
@@ -200,16 +200,12 @@ class BioinformaticAnalysisParser implements DatasetParser<NfCorePipelineResult>
     private static void parsePipelineInformation(Map pipelineInformation) {
 
         pipelineInformation.get("children").each { Map child ->
-            switch (child.get("name")) {
-                case "software_versions.yml":
-                    insertAsProperty(pipelineInformation, child, RequiredPipelineFileKeys.SOFTWARE_VERSIONS.getKeyName())
-                    break
-                case "execution_report.html":
-                    insertAsProperty(pipelineInformation, child, RequiredPipelineFileKeys.EXECUTION_REPORT.getKeyName())
-                    break
-                default:
-                    //ignoring other children
-                    break
+            String filename = child.get("name")
+            if(filename.equals("software_versions.yml")){
+                insertAsProperty(pipelineInformation, child, RequiredPipelineFileKeys.SOFTWARE_VERSIONS.getKeyName())
+            }
+            else if(filename.matches("^execution_report.*")) {
+                insertAsProperty(pipelineInformation, child, RequiredPipelineFileKeys.EXECUTION_REPORT.getKeyName())
             }
         }
     }

--- a/src/test/groovy/life/qbic/utils/BioinformaticAnalysisSpec.groovy
+++ b/src/test/groovy/life/qbic/utils/BioinformaticAnalysisSpec.groovy
@@ -60,8 +60,8 @@ class BioinformaticAnalysisSpec extends Specification {
         assert softwareVersions.getName() == "software_versions.yml"
 
         ExecutionReport executionReport = pipelineInfo.getExecutionReport()
-        assert executionReport.getRelativePath() == "./pipeline_info/execution_report.html"
-        assert executionReport.getName() == "execution_report.html"
+        assert executionReport.getRelativePath() == "./pipeline_info/execution_report_1234-56-78_90-12-34.html"
+        assert executionReport.getName() == "execution_report_1234-56-78_90-12-34.html"
 
 
     }
@@ -104,7 +104,7 @@ class BioinformaticAnalysisSpec extends Specification {
 
     def "parsing a file throws a DataParserException"() {
         given:
-        def pathToDirectory = Paths.get(exampleDirectoriesRoot, "validates/pipeline_info/execution_report.html")
+        def pathToDirectory = Paths.get(exampleDirectoriesRoot, "validates/pipeline_info/execution_report_1234-56-78_90-12-34.html")
         when:
         bioinformaticAnalysisParser.parseFrom(pathToDirectory)
         then:


### PR DESCRIPTION
**What was changed** 
Fix parsing of execution_report.html parsing to allow for timestamps in the filename 

